### PR TITLE
Introduce `postNonBlocking`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 .DS_STORE
+.vscode

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ let result = await client.post('sum', 19, 23);
 console.log(`The answer to life, the universe and everything is ${result}`);
 ```
 
+> *Note*: `.post` calls that take a long time to resolve will cause the JourneyApps Container to bring up a blocking spinner. To make a `.post` call without bringing up a blocking spinner, use `.postNonBlocking`
+
 ```javascript
 // In your view's JS
 
@@ -63,6 +65,10 @@ function sendTasksToClient() {
 
 ```typescript
 post(cmd: string, param1?: any, ..., paramN?: any) : Promise<any>
+```
+
+```typescript
+postNonBlocking(cmd: string, param1?: any, ..., paramN?: any) : Promise<any>
 ```
 
 ```typescript

--- a/src/lib/bridge.ts
+++ b/src/lib/bridge.ts
@@ -28,10 +28,11 @@ export class Bridge {
   private async _post(message: PostMessage) {
     return this.proxy.postMessage<PostMessageResponse>(this.target, message);
   }
-  async post(command: string, params: any[] = []) {
+  async post(command: string, params: any[] = [], options = {}) {
     return this._post({
       command: command,
-      params
+      params,
+      options
     });
   }
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -15,8 +15,16 @@ export default class JourneyIFrameClient {
     this.callbacks = {};
   }
   async post(expression: string, ...params: any[]) {
+    return this._performPost(expression, params);
+  }
+  async postNonBlocking(expression: string, ...params: any[]) {
+    return this._performPost(expression, params, {
+      nonBlocking: true
+    });
+  }
+  async _performPost(expression: string, params: any[] = [], options = {}) {
     try {
-      return (await this.bridge.post(expression, params)).result;
+      return (await this.bridge.post(expression, params, options)).result;
     } catch (e) {
       if (e.error) {
         // Journey error. Strip windowPostMessageProxy info and return

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -23,7 +23,8 @@ test('We can send a command and params to the window parent', async () => {
   CASES.forEach(params => {
     expect(wpmpInstance.postMessage).toHaveBeenCalledWith(window.parent, {
       command: COMMAND,
-      params: sanitize(params)
+      params: sanitize(params),
+      options: {}
     });
   });
 });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -4,7 +4,7 @@ import { Bridge } from '../src/lib/bridge';
 
 jest.mock('../src/lib/bridge');
 
-describe('client.post', () => {
+describe('client.post blocking', () => {
   let client;
   let bridgeInstance;
   const MOCK_RESULT = 'result';
@@ -21,23 +21,67 @@ describe('client.post', () => {
     let result = await client.post(COMMAND_NAME);
 
     expect(result).toBe(MOCK_RESULT);
-    expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, []);
+    expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, [], {});
   });
 
   test('should post correctly with 1 parameter', async () => {
     let result = await client.post(COMMAND_NAME, 'param1');
 
     expect(result).toBe(MOCK_RESULT);
-    expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, ['param1']);
+    expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, ['param1'], {});
   });
 
   test('should post correctly with 2 parameters', async () => {
     let result = await client.post(COMMAND_NAME, 'param1', 'param2');
 
     expect(result).toBe(MOCK_RESULT);
-    expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, [
-      'param1',
-      'param2'
-    ]);
+    expect(bridgeInstance.post).toBeCalledWith(
+      COMMAND_NAME,
+      ['param1', 'param2'],
+      {}
+    );
+  });
+});
+
+describe('client.post non-blocking', () => {
+  let client;
+  let bridgeInstance;
+  const MOCK_RESULT = 'result';
+  const COMMAND_NAME = 'my-awesome-command';
+  beforeEach(() => {
+    (Bridge as any).mockClear();
+    client = new JourneyIFrameClient();
+    bridgeInstance = (Bridge as any).mock.instances[0];
+    // Mock the return value for bridge (using mockResolvedValue to wrap it in a promise)
+    bridgeInstance.post.mockResolvedValue({ result: MOCK_RESULT });
+  });
+
+  test('should post correctly with 0 parameters', async () => {
+    let result = await client.postNonBlocking(COMMAND_NAME);
+
+    expect(result).toBe(MOCK_RESULT);
+    expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, [], {
+      nonBlocking: true
+    });
+  });
+
+  test('should post correctly with 1 parameter', async () => {
+    let result = await client.postNonBlocking(COMMAND_NAME, 'param1');
+
+    expect(result).toBe(MOCK_RESULT);
+    expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, ['param1'], {
+      nonBlocking: true
+    });
+  });
+
+  test('should post correctly with 2 parameters', async () => {
+    let result = await client.postNonBlocking(COMMAND_NAME, 'param1', 'param2');
+
+    expect(result).toBe(MOCK_RESULT);
+    expect(bridgeInstance.post).toBeCalledWith(
+      COMMAND_NAME,
+      ['param1', 'param2'],
+      { nonBlocking: true }
+    );
   });
 });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -4,7 +4,7 @@ import { Bridge } from '../src/lib/bridge';
 
 jest.mock('../src/lib/bridge');
 
-describe('client.post blocking', () => {
+describe('client.post', () => {
   let client;
   let bridgeInstance;
   const MOCK_RESULT = 'result';
@@ -17,71 +17,64 @@ describe('client.post blocking', () => {
     bridgeInstance.post.mockResolvedValue({ result: MOCK_RESULT });
   });
 
-  test('should post correctly with 0 parameters', async () => {
-    let result = await client.post(COMMAND_NAME);
+  describe('Blocking', () => {
+    test('should post correctly with 0 parameters', async () => {
+      let result = await client.post(COMMAND_NAME);
 
-    expect(result).toBe(MOCK_RESULT);
-    expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, [], {});
-  });
+      expect(result).toBe(MOCK_RESULT);
+      expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, [], {});
+    });
 
-  test('should post correctly with 1 parameter', async () => {
-    let result = await client.post(COMMAND_NAME, 'param1');
+    test('should post correctly with 1 parameter', async () => {
+      let result = await client.post(COMMAND_NAME, 'param1');
 
-    expect(result).toBe(MOCK_RESULT);
-    expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, ['param1'], {});
-  });
+      expect(result).toBe(MOCK_RESULT);
+      expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, ['param1'], {});
+    });
 
-  test('should post correctly with 2 parameters', async () => {
-    let result = await client.post(COMMAND_NAME, 'param1', 'param2');
+    test('should post correctly with 2 parameters', async () => {
+      let result = await client.post(COMMAND_NAME, 'param1', 'param2');
 
-    expect(result).toBe(MOCK_RESULT);
-    expect(bridgeInstance.post).toBeCalledWith(
-      COMMAND_NAME,
-      ['param1', 'param2'],
-      {}
-    );
-  });
-});
-
-describe('client.post non-blocking', () => {
-  let client;
-  let bridgeInstance;
-  const MOCK_RESULT = 'result';
-  const COMMAND_NAME = 'my-awesome-command';
-  beforeEach(() => {
-    (Bridge as any).mockClear();
-    client = new JourneyIFrameClient();
-    bridgeInstance = (Bridge as any).mock.instances[0];
-    // Mock the return value for bridge (using mockResolvedValue to wrap it in a promise)
-    bridgeInstance.post.mockResolvedValue({ result: MOCK_RESULT });
-  });
-
-  test('should post correctly with 0 parameters', async () => {
-    let result = await client.postNonBlocking(COMMAND_NAME);
-
-    expect(result).toBe(MOCK_RESULT);
-    expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, [], {
-      nonBlocking: true
+      expect(result).toBe(MOCK_RESULT);
+      expect(bridgeInstance.post).toBeCalledWith(
+        COMMAND_NAME,
+        ['param1', 'param2'],
+        {}
+      );
     });
   });
+  describe('Non-blocking', () => {
+    test('should post correctly with 0 parameters', async () => {
+      let result = await client.postNonBlocking(COMMAND_NAME);
 
-  test('should post correctly with 1 parameter', async () => {
-    let result = await client.postNonBlocking(COMMAND_NAME, 'param1');
-
-    expect(result).toBe(MOCK_RESULT);
-    expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, ['param1'], {
-      nonBlocking: true
+      expect(result).toBe(MOCK_RESULT);
+      expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, [], {
+        nonBlocking: true
+      });
     });
-  });
 
-  test('should post correctly with 2 parameters', async () => {
-    let result = await client.postNonBlocking(COMMAND_NAME, 'param1', 'param2');
+    test('should post correctly with 1 parameter', async () => {
+      let result = await client.postNonBlocking(COMMAND_NAME, 'param1');
 
-    expect(result).toBe(MOCK_RESULT);
-    expect(bridgeInstance.post).toBeCalledWith(
-      COMMAND_NAME,
-      ['param1', 'param2'],
-      { nonBlocking: true }
-    );
+      expect(result).toBe(MOCK_RESULT);
+      expect(bridgeInstance.post).toBeCalledWith(COMMAND_NAME, ['param1'], {
+        nonBlocking: true
+      });
+    });
+
+    test('should post correctly with 2 parameters', async () => {
+      let result = await client.postNonBlocking(
+        COMMAND_NAME,
+        'param1',
+        'param2'
+      );
+
+      expect(result).toBe(MOCK_RESULT);
+      expect(bridgeInstance.post).toBeCalledWith(
+        COMMAND_NAME,
+        ['param1', 'param2'],
+        { nonBlocking: true }
+      );
+    });
   });
 });


### PR DESCRIPTION
`post` will bring up a blocking spinner in the JourneyApps Container, but using `postNonBlocking` tells the Container not to bring up the spinner.